### PR TITLE
Fix HTML validation errors

### DIFF
--- a/example-iframe-src.html
+++ b/example-iframe-src.html
@@ -1,7 +1,4 @@
----
-title: "Example iFrame Source"
-permalink: /example-iframe-src.html
----
+<!DOCTYPE html>
 <html lang="en">
 	<head>	
 		<meta charset="utf-8">

--- a/index.html
+++ b/index.html
@@ -1614,8 +1614,8 @@
 			<!-- ruby -->
 			<a id="ruby"></a>
 			<h4><a href="#ruby"><code>&lt;ruby&gt;</code></a></h4>
-			<p>Also: <a href="#rp"><code>&lt;rp&gt;</code></a>,
-				<a href="#rt"><code>&lt;rt&gt;</code></a>, 
+			<p>Also: <a><code>&lt;rp&gt;</code></a>,
+				<a><code>&lt;rt&gt;</code></a>,
 			<p>The HTML <code>&lt;ruby&gt;</code> element represents a ruby annotation. Ruby annotations are for showing pronunciation of East Asian characters.</p>
 			<details open>
 				<summary>Example</summary>

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 	<head>	
 		<meta charset="utf-8">
@@ -49,10 +50,10 @@
 
 			<hr />
 			<form id="go-to-element" onsubmit="elementNavigationHandler(event);">
-				<label for"element-navigation">Jump to Element</label>
+				<label for="element-navigation">Jump to Element</label>
 				<br />
 				<select name="element-navigation" id="element-navigation">
-						<option value="example-html-elements"></option>
+						<option value="example-html-elements" label="Element"></option>
 						<option value="a">a</option>
 						<option value="abbr">abbr</option>
 						<option value="address">address</option>
@@ -170,7 +171,7 @@
 			<h4><a href="#abbr"><code>&lt;abbr&gt;</code></a></h4>
 			<p>
 				The HTML Abbreviation element <code>&lt;abbr&gt;</code> represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation.
-				</br ><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr">More at MDN →</a>
+				<br><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
@@ -241,7 +242,7 @@
 			<a name="audio"></a>
 			<h4><a href="#audio"><code>&lt;audio&gt;</code></a></h4>
 			<p>
-				The HTML <code>&lt;audio&gt;</code> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the src attribute or the <source> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
+				The HTML <code>&lt;audio&gt;</code> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the <code>src</code> attribute or the <code>&lt;source&gt;</code> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
 				<br />
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio">More at MDN →</a>
 			</p>
@@ -388,7 +389,7 @@
 			<a name="data"></a>
 			<h4><a href="#data"><code>&lt;data&gt;</code></a></h4>
 			<p>
-				The HTML <code>&lt;data&gt;</code> element links a given content with a machine-readable translation. If the content is time- or date-related, the <time> element must be used.
+				The HTML <code>&lt;data&gt;</code> element links a given content with a machine-readable translation. If the content is time- or date-related, the <code>&lt;time&gt;</code> element must be used.
 				<br />
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data">More at MDN →</a>
 			</p>
@@ -418,7 +419,7 @@
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<label for="beverage-choice">Favorite hot beverage:</label>
+					<label for="beverage-choice-input">Favorite hot beverage:</label>
 					<input list="beverage-choice" id="beverage-choice-input" name="beverage-choice" />
 					<datalist id="beverage-choice">
 						<option value="Aleberry">
@@ -610,7 +611,7 @@
 			<a name="label"></a>
 			<a name="legend"></a>
 			<h4><a href="#fieldset"><code>&lt;fieldset&gt;</code></a></h4>
-			<p>Also: <a href="#label"><code>&lt;label&gt;</code>, <a href="#legend"><code>&lt;legend&gt;</code></a>
+			<p>Also: <a href="#label"><code>&lt;label&gt;</code></a>, <a href="#legend"><code>&lt;legend&gt;</code></a>
 			<p>
 				The HTML <code>&lt;fieldset&gt;</code> element is used to group several controls as well as labels (<code>&lt;label&gt;</code>) within a web form.
 				<br />
@@ -662,7 +663,7 @@
 			<a name="figcaption"></a>
 			<a name="img"></a>
 			<h4><a href="#figure"><code>&lt;figure&gt;</code></a></h4>
-			<p>Also: <a href="#figcaption"><code>&lt;figcaption&gt;</code>, <a href="#img"><code>&lt;img&gt;</code></a>
+			<p>Also: <a href="#figcaption"><code>&lt;figcaption&gt;</code></a>, <a href="#img"><code>&lt;img&gt;</code></a>
 			<p>
 				The HTML <code>&lt;figure&gt;</code> (Figure With Optional Caption) element represents self-contained content, potentially with an optional caption, which is specified using the (<code>&lt;figcaption&gt;</code>) element.
 				<br />
@@ -717,7 +718,7 @@
 							</li>
 							<li>
 								<label for="message">Message</label><br />
-								<textarea id="message" required placeholder="Ahoy!"/></textarea>
+								<textarea id="message" required placeholder="Ahoy!"></textarea>
 							</li>
 						
 							<li>
@@ -871,8 +872,7 @@
 				<section>
 					<hgroup>
 						<h1>An h1 element</h1>
-						<h2>An h2 element</h2>
-						<h3>An h3 element</h3>
+						<p>A p element</p>
 					</hgroup>
 					<p>A paragraph of text following an hgroup element.</p>
 				</section>
@@ -984,7 +984,7 @@
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<input type="color" id="input-type-color" name="input-type-color" value="color" />
+					<input type="color" id="input-type-color" name="input-type-color" value="#990000" />
 					<label for="input-type-color">Input Type=color</label> 
 				</section>
 			</details>
@@ -1002,7 +1002,7 @@
 				<summary>Example</summary>
 				<section>
 					<label for="input-type-date">Input Type=date</label>
-					<input type="date" id="input-type-date" name="input-type-date" min="2001-01-01" max="2020-01-01" placeholder="2001-01-01">
+					<input type="date" id="input-type-date" name="input-type-date" min="2001-01-01" max="2020-01-01">
 				</section>
 			</details>
 			<aside></aside>
@@ -1020,7 +1020,7 @@
 				<summary>Example</summary>
 				<section>
 					<label for="input-type-datetime-local">Input Type=datetime-local</label>
-					<input type="datetime-local" id="input-type-datetime-local" name="input-type-datetime-local" min="2001-01-01" max="2020-01-01" placeholder="2001-01-01T16:00:00">
+					<input type="datetime-local" id="input-type-datetime-local" name="input-type-datetime-local" min="2001-01-01T00:00:00" max="2020-01-01T23:59:59">
 				</section>
 			</details>
 			<hr />
@@ -1071,7 +1071,7 @@
 				<summary>Example</summary>
 				<section>
 					<label for="input-type-image">Input Type=image</label>
-					<input type="input-type-image" id="input-type-image" alt="Image Button" src="/media/examples/login-button.png">
+					<input type="image" id="input-type-image" alt="Image Button" src="/media/examples/login-button.png">
 				</section>
 			</details>
 			<hr />
@@ -1268,7 +1268,7 @@
 				<summary>Example</summary>
 				<section>
 					<p>A paragraph of text preceeding an <code>&lt;ins&gt;</code> element.</p>
-					<ins cite="TODO" datetime="2018-05">
+					<ins cite="TODO" datetime="2018-05-01T00:00:00Z">
 						<p>A paragraph of text within an <code>&lt;ins&gt;</code> element.</p>
 					</ins>
 					<p>A paragraph of text following an <code>&lt;ins&gt;</code> element.</p>
@@ -1348,11 +1348,7 @@
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></p>
 			<details open>
 				<summary>Example</summary>
-				<section>
-					<main>
-						<p>A main element</p>
-					</main>
-				</section>
+				<p>Most of this document is in a <code>&lt;main&gt;</code> element.  Only one visible <code>&lt;main&gt;</code> element is allowed.</p>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></aside>
 			<hr />
@@ -1376,7 +1372,7 @@
 						<area shape="rect" coords="184,56,192,64" alt="Bird 3" href="#area-bird-3">
 						<area shape="rect" coords="140,116,178,138" alt="Bench" href="#area-bench">
 					</map>
-					<img width="320px" usemap="#areamap" src="./images/undraw-through-the-park.svg" alt="Through the Park" />
+					<img width="320" usemap="#areamap" src="./images/undraw-through-the-park.svg" alt="Through the Park" />
 					<figcaption>Illustration by <a href="https://twitter.com/undraw_co">Katerina Limpitsouni</a> on <a href="https://undraw.co">unDraw</a>.
 					</figcaption>
 				</figure>	
@@ -1563,7 +1559,7 @@
 				<section>
 					<figure>
 					<picture>
-						<source srcset="./images/matthew-howell-uYoClFUGvkk-unsplash.jpg" media="(min-width: 600px)" title="A wave crashing on the shore in Cape Henlopen State Park, DE" alt="A wave crashing on the shore in Cape Henlopen State Park, DE.">
+						<source srcset="./images/matthew-howell-uYoClFUGvkk-unsplash.jpg" media="(min-width: 600px)" title="A wave crashing on the shore in Cape Henlopen State Park, DE">
 							<img src="./images/matthew-howell-uYoClFUGvkk-unsplash-small.jpg" title="A wave crashing on the shore in Cape Henlopen State Park, DE" alt="A wave crashing on the shore in Cape Henlopen State Park, DE.">
 					</picture>
 					<figcaption>This example uses the picture element to display a higher resolution image to wider viewports (> 600 pixels).</figcaption>
@@ -1687,7 +1683,7 @@
 				<summary>Example</summary>
 				<section>
 					<label for="pet-select">Choose a pet:</label>
-					<select name="pets" id="pet-select">
+					<select name="pets" id="pet-select-2">
 						<option value="">--Please choose an option--</option>
 						<option value="dog">Dog</option>
 						<option value="cat">Cat</option>
@@ -1720,7 +1716,7 @@
 			<a name="span"></a>
 			<h4><a href="#span"><code>&lt;span&gt;</code></a></h4>
 			<p>
-				The HTML <span> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang.
+				The HTML <code>&lt;span&gt;</code> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang.
 				<br />
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span">More at MDN →</a>
 			</p>
@@ -1752,7 +1748,7 @@
 			<a name="sub"></a>
 			<h4><a href="#sub"><code>&lt;sub&gt;</code></a></h4>
 			<p>
-				The HTML Subscript element (<sub>) specifies inline text which should be displayed as subscript for solely typographical reasons.
+				The HTML Subscript element (<code>&lt;sub&gt;</code>) specifies inline text which should be displayed as subscript for solely typographical reasons.
 				<br />
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub">More at MDN →</a>
 			</p>
@@ -1818,6 +1814,11 @@
 				<section>
 					<table>
 						<caption>A table caption element</caption>
+						<colgroup>
+							<col>
+							<col span="2" class="batman">
+							<col span="2" class="flash">
+						</colgroup>
 						<thead>
 							<tr>
 							  <th>th 1</th>
@@ -1827,11 +1828,6 @@
 							  <th>th2</th>
 							</tr>
 						</thead>
-						<colgroup>
-							<col>
-							<col span="2" class="batman">
-							<col span="2" class="flash">
-						</colgroup>
 						<tr>
 							<td> </td>
 							<th scope="col">Batman</th>
@@ -1851,7 +1847,7 @@
 						<tfoot>
 							<tr>
 							  <td>Footer content 1</td>
-							  <td>Footer content 2</td>
+							  <td colspan="4">Footer content 2</td>
 							</tr>
 						  </tfoot>
 					</table>					
@@ -1870,7 +1866,7 @@
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<p>At <time datetime="15:30:08">around 3:30PM UTC</time> on <time datetime="292277026596-12-04">Sunday, 4 December in the year 292277026596</time> 64-bit Unix timestamps will no longer work. We have a little more than thirteen billion years to solve the problem.</p>
+					<p>At <time datetime="03:14:07">around 3:14AM UTC</time> on <time datetime="2038-01-19">Tuesday, 19 January in the year 2038</time> 32-bit Unix timestamps will no longer work.</p>
 				</section>
 			</details>
 			<hr />
@@ -2027,7 +2023,7 @@
 			<p>All photographs are from <a href="https://www.matthewhowell.net">Matthew Howell</a>, available for use, for free at <a href="https://unsplash.com/@matthewhowell">Unsplash</a>.</p>
 			
 		</section>
-		
+
 	<script>
 		// a handler for the example <form> element submit
 		const formElementHandler = function(event) {

--- a/index.html
+++ b/index.html
@@ -1348,7 +1348,7 @@
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></p>
 			<details open>
 				<summary>Example</summary>
-				<p>Most of this document is in a <code>&lt;main&gt;</code> element.  Only one visible <code>&lt;main&gt;</code> element is allowed.</p>
+				<p>The beginning of this document has a <code>&lt;main&gt;</code> element.  Only one visible <code>&lt;main&gt;</code> element is allowed.</p>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></aside>
 			<hr>

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
 		
 		<!-- elements -->
 		<section>
-			<a name="example-html-elements"></a>
+			<a id="example-html-elements"></a>
 			<h2>Example HTML Elements</h2>
 			<p>Reasonable.html includes examples of most HTML elments listed in <a title="Mozilla HTML Element Reference" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element">Mozilla's HTML Element Reference</a>, which mirrors the <a title="W3C HTML 5.2 specification" href="https://www.w3.org/TR/html52/">W3C HTML 5.2 specification</a>. Each is presented below, ordered alphabetically.</p>
 
@@ -152,7 +152,7 @@
 			<hr />
 
 			<!-- a -->
-			<a name="a"></a>
+			<a id="a"></a>
 			<h4><a href="#a"><code>&lt;a&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;a&gt;</code> element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
@@ -167,7 +167,7 @@
 			<hr />
 
 			<!-- abbr -->
-			<a name="abbr"></a>
+			<a id="abbr"></a>
 			<h4><a href="#abbr"><code>&lt;abbr&gt;</code></a></h4>
 			<p>
 				The HTML Abbreviation element <code>&lt;abbr&gt;</code> represents an abbreviation or acronym; the optional title attribute can provide an expansion or description for the abbreviation.
@@ -182,7 +182,7 @@
 			<hr />
 
 			<!-- address -->
-			<a name="address"></a>
+			<a id="address"></a>
 			<h4><a href="#address"><code>&lt;address&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;address&gt;</code> element indicates that the enclosed HTML provides contact information for a person or people, or for an organization.
@@ -201,7 +201,7 @@
 			<hr />
 
 			<!-- article -->
-			<a name="article"></a>
+			<a id="article"></a>
 			<h4><a href="#article"><code>&lt;article&gt;</code></a></h4>
 			<p>The HTML <code>&lt;article&gt;</code> element represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e.g., in syndication).</p>
 			<details open>
@@ -221,7 +221,7 @@
 			<hr />
 
 			<!-- aside -->
-			<a name="aside"></a>
+			<a id="aside"></a>
 			<h4><a href="#aside"><code>&lt;aside&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;aside&gt;</code> element represents a portion of a document whose content is only indirectly related to the document's main content.
@@ -239,7 +239,7 @@
 			<hr />
 
 			<!-- audio -->
-			<a name="audio"></a>
+			<a id="audio"></a>
 			<h4><a href="#audio"><code>&lt;audio&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;audio&gt;</code> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the <code>src</code> attribute or the <code>&lt;source&gt;</code> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
@@ -260,7 +260,7 @@
 			<hr />
 			
 			<!-- b -->
-			<a name="b"></a>
+			<a id="b"></a>
 			<h4><a href="#b"><code>&lt;b&gt;</code></a></h4>
 			<p>
 				The HTML Bring Attention To element <code>&lt;b&gt;</code> is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance.
@@ -276,7 +276,7 @@
 			<hr />
 
 			<!-- bdi -->
-			<a name="bdi"></a>
+			<a id="bdi"></a>
 			<h4><a href="#bdi"><code>&lt;bdi&gt;</code></a></h4>
 			<p>
 				The HTML Bidirectional Isolate element <code>&lt;bdi&gt;</code> tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text.
@@ -293,7 +293,7 @@
 			<hr />
 
 			<!-- bdo -->
-			<a name="bdo"></a>
+			<a id="bdo"></a>
 			<h4><a href="#bdo"><code>&lt;bdo&gt;</code></a></h4>
 			<p>
 				The HTML Bidirectional Text Override element <code>&lt;bdo&gt;</code> overrides the current directionality of text, so that the text within is rendered in a different direction.
@@ -310,7 +310,7 @@
 			<hr />
 
 			<!-- blockquote -->
-			<a name="blockquote"></a>
+			<a id="blockquote"></a>
 			<h4><a href="#blockquote"><code>&lt;blockquote&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;blockquote&gt;</code>  Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <code>&lt;cite&gt;</code> element.
@@ -331,7 +331,7 @@
 			<hr />
 
 			<!-- button -->
-			<a name="button"></a>
+			<a id="button"></a>
 			<h4><a href="#button"><code>&lt;button&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;button&gt;</code> element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality.
@@ -347,7 +347,7 @@
 			<hr />
 			
 			<!-- cite -->
-			<a name="cite"></a>
+			<a id="cite"></a>
 			<h4><a href="#cite"><code>&lt;cite&gt;</code></a></h4>
 			<p>
 				The HTML Citation element <code>&lt;cite&gt;</code> is used to describe a reference to a cited creative work, and must include the title of that work.
@@ -369,7 +369,7 @@
 			<hr />
 
 			<!-- code -->
-			<a name="code"></a>
+			<a id="code"></a>
 			<h4><a href="#code"><code>&lt;code&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;code&gt;</code> element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font.
@@ -386,7 +386,7 @@
 			<hr />
 
 			<!-- data -->
-			<a name="data"></a>
+			<a id="data"></a>
 			<h4><a href="#data"><code>&lt;data&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;data&gt;</code> element links a given content with a machine-readable translation. If the content is time- or date-related, the <code>&lt;time&gt;</code> element must be used.
@@ -409,7 +409,7 @@
 			<hr />
 			
 			<!-- datalist -->
-			<a name="datalist"></a>
+			<a id="datalist"></a>
 			<h4><a href="#datalist"><code>&lt;datalist&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;datalist&gt;</code> element contains a set of <code>&lt;option&gt;</code> elements that represent the permissible or recommended options available to choose from within other controls.
@@ -459,7 +459,7 @@
 			<hr />
 
 			<!-- del -->
-			<a name="del"></a>
+			<a id="del"></a>
 			<h4><a href="#del"><code>&lt;del&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;del&gt;</code> element represents a range of text that has been deleted from a document.
@@ -479,8 +479,8 @@
 			<hr />
 
 			<!-- details -->
-			<a name="details"></a>
-			<a name="summary"></a>
+			<a id="details"></a>
+			<a id="summary"></a>
 			<h4><a href="#details"><code>&lt;details&gt;</code></a></h4>
 			<p>Also: <a href="#summary"><code>&lt;summary&gt;</code></a>
 			<p>
@@ -500,7 +500,7 @@
 			<hr />
 			
 			<!-- dfn -->
-			<a name="dfn"></a>
+			<a id="dfn"></a>
 			<h4><a href="#dfn"><code>&lt;dfn&gt;</code></a></h4>
 			<p>
 				The HTML Definition element (<code>&lt;dfn&gt;</code>) is used to indicate the term being defined within the context of a definition phrase or sentence. The <code>&lt;p&gt;</code> element, the <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> pairing, or the <code>&lt;section&gt;</code> element which is the nearest ancestor of the <code>&lt;dfn&gt;</code> is considered to be the definition of the term.
@@ -516,7 +516,7 @@
 			<hr />
 			
 			<!-- div -->
-			<a name="div"></a>
+			<a id="div"></a>
 			<h4><a href="#div"><code>&lt;div&gt;</code></a></h4>
 			<p>
 				The HTML Content Division element (<code>&lt;div&gt;</code>) is the generic container for flow content. It has no effect on the content or layout until styled using CSS.
@@ -534,9 +534,9 @@
 			<hr />
 
 			<!-- dl -->
-			<a name="dl"></a>
-			<a name="dd"></a>
-			<a name="dt"></a>
+			<a id="dl"></a>
+			<a id="dd"></a>
+			<a id="dt"></a>
 			<h4><a href="#dl"><code>&lt;dl&gt;</code></a></h4>
 			<p>Also: <a href="#dd"><code>&lt;dd&gt;</code></a>,
 				<a href="#dt"><code>&lt;dt&gt;</code></a></p>
@@ -588,7 +588,7 @@
 			<hr />
 
 			<!-- em -->
-			<a name="em"></a>
+			<a id="em"></a>
 			<h4><a href="#em"><code>&lt;em&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;em&gt;</code> element marks text that has stress emphasis. The <code>&lt;em&gt;</code> element can be nested, with each level of nesting indicating a greater degree of emphasis.
@@ -607,9 +607,9 @@
 			<!-- fieldset -->
 			<!-- label -->
 			<!-- legend -->
-			<a name="fieldset"></a>
-			<a name="label"></a>
-			<a name="legend"></a>
+			<a id="fieldset"></a>
+			<a id="label"></a>
+			<a id="legend"></a>
 			<h4><a href="#fieldset"><code>&lt;fieldset&gt;</code></a></h4>
 			<p>Also: <a href="#label"><code>&lt;label&gt;</code></a>, <a href="#legend"><code>&lt;legend&gt;</code></a>
 			<p>
@@ -659,9 +659,9 @@
 			<hr />
 
 			<!-- figure -->
-			<a name="figure"></a>
-			<a name="figcaption"></a>
-			<a name="img"></a>
+			<a id="figure"></a>
+			<a id="figcaption"></a>
+			<a id="img"></a>
 			<h4><a href="#figure"><code>&lt;figure&gt;</code></a></h4>
 			<p>Also: <a href="#figcaption"><code>&lt;figcaption&gt;</code></a>, <a href="#img"><code>&lt;img&gt;</code></a>
 			<p>
@@ -681,7 +681,7 @@
 			<hr />
 			
 			<!-- footer -->
-			<a name="footer"></a>
+			<a id="footer"></a>
 			<h4><a href="#footer"><code>&lt;footer&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;footer&gt;</code> element represents a footer for its nearest sectioning content or sectioning root element. A footer typically contains information about the author of the section, copyright data or links to related documents.
@@ -697,8 +697,8 @@
 			<hr />
 
 			<!-- form -->
-			<a name="form"></a>
-			<a name="textarea"></a>
+			<a id="form"></a>
+			<a id="textarea"></a>
 			<h4><a href="#form"><code>&lt;form&gt;</code></a></h4>
 			<p>Also: <a href="#textarea"><code>&lt;textarea&gt;</code></a>
 			<p>
@@ -742,7 +742,7 @@
 			<hr />
 
 			<!-- h1 -->
-			<a name="h1"></a>
+			<a id="h1"></a>
 			<h4><a href="#h1"><code>&lt;h1&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h1&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -759,7 +759,7 @@
 			<hr />
 
 			<!-- h2 -->
-			<a name="h2"></a>
+			<a id="h2"></a>
 			<h4><a href="#h2"><code>&lt;h2&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h2&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -776,7 +776,7 @@
 			<hr />
 
 			<!-- h3 -->
-			<a name="h3"></a>
+			<a id="h3"></a>
 			<h4><a href="#h3"><code>&lt;h3&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h3&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -793,7 +793,7 @@
 			<hr />
 
 			<!-- h4 -->
-			<a name="h4"></a>
+			<a id="h4"></a>
 			<h4><a href="#h4"><code>&lt;h4&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h4&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -810,7 +810,7 @@
 			<hr />
 
 			<!-- h5 -->
-			<a name="h5"></a>
+			<a id="h5"></a>
 			<h4><a href="#h5"><code>&lt;h5&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h5&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -827,7 +827,7 @@
 			<hr />
 
 			<!-- h6 -->
-			<a name="h6"></a>
+			<a id="h6"></a>
 			<h4><a href="#h6"><code>&lt;h6&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h6&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
@@ -844,7 +844,7 @@
 			<hr />
 
 			<!-- header -->
-			<a name="header"></a>
+			<a id="header"></a>
 			<h4><a href="#header"><code>&lt;header&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;header&gt;</code> element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements.
@@ -860,7 +860,7 @@
 			<hr />
 
 			<!-- hgroup -->
-			<a name="hgroup"></a>
+			<a id="hgroup"></a>
 			<h4><a href="#hgroup"><code>&lt;hgroup&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;hgroup&gt;</code> element represents a multi-level heading for a section of a document. It groups a set of <code>&lt;h1&gt; - &lt;h6&gt;</code> elements.
@@ -880,7 +880,7 @@
 			<hr />
 
 			<!-- hr -->
-			<a name="hr"></a>
+			<a id="hr"></a>
 			<h4><a href="#hr"><code>&lt;hr&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;hr&gt;</code> element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
@@ -898,7 +898,7 @@
 			<hr />
 
 			<!-- i -->
-			<a name="i"></a>
+			<a id="i"></a>
 			<h4><a href="#i"><code>&lt;i&gt;</code></a></h4>
 			<p>
 				The HTML Interesting Text element <code>&lt;i&gt;</code> represents a range of text that is set off from the normal text for some reason.
@@ -914,7 +914,7 @@
 			<hr />
 
 			<!-- iframe -->
-			<a name="iframe"></a>
+			<a id="iframe"></a>
 			<h4><a href="#iframe"><code>&lt;iframe&gt;</code></a></h4>
 			<p>
 				The HTML Inline Frame element (<code>&lt;iframe&gt;</code>) represents a nested browsing context, embedding another HTML page into the current one.
@@ -940,7 +940,7 @@
 			<p>The HTML <code>&lt;input&gt;</code> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.</p>
 
 			<!-- input-button -->
-			<a name="input-button"></a>
+			<a id="input-button"></a>
 			<h4><a href="#input-button"><code>&lt;input[type=button]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=button]&gt;</code> is a push button with no default behavior displaying the value of the value attribute, empty by default.
@@ -957,7 +957,7 @@
 			<hr />
 
 			<!-- input-checkbox -->
-			<a name="input-checkbox"></a>
+			<a id="input-checkbox"></a>
 			<h4><a href="#input-checkbox"><code>&lt;input[type=checkbox]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=checkbox]&gt;</code> is a check box allowing single values to be selected/deselected.
@@ -974,7 +974,7 @@
 			<hr />
 
 			<!-- input-color -->
-			<a name="input-color"></a>
+			<a id="input-color"></a>
 			<h4><a href="#input-color"><code>&lt;input[type=color]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=color]&gt;</code> is a control for specifying a color; opening a color picker when active in supporting browsers.
@@ -991,7 +991,7 @@
 			<hr />
 
 			<!-- input-date -->
-			<a name="input-date"></a>
+			<a id="input-date"></a>
 			<h4><a href="#input-date"><code>&lt;input[type=date]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=date]&gt;</code> is a control for entering a date (year, month, and day, with no time). Opens a date picker or numeric wheels for year, month, day when active in supporting browsers.
@@ -1009,7 +1009,7 @@
 			<hr />
 
 			<!-- input-datetime-local -->
-			<a name="input-datetime-local"></a>
+			<a id="input-datetime-local"></a>
 			<h4><a href="#input-datetime-local"><code>&lt;input[type=datetime-local]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=datetime-local]&gt;</code> is a control for entering a date and time, with no time zone. Opens a date picker or numeric wheels for date- and time-components when active in supporting browsers.
@@ -1026,7 +1026,7 @@
 			<hr />
 
 			<!-- input-email -->
-			<a name="input-email"></a>
+			<a id="input-email"></a>
 			<h4><a href="#input-email"><code>&lt;input[type=email]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=email]&gt;</code> is a field for editing an email address. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards.
@@ -1043,7 +1043,7 @@
 			<hr />
 
 			<!-- input-file -->
-			<a name="input-file"></a>
+			<a id="input-file"></a>
 			<h4><a href="#input-file"><code>&lt;input[type=file]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=file]&gt;</code> is a control that lets the user select a file. Use the accept attribute to define the types of files that the control can select.
@@ -1060,7 +1060,7 @@
 			<hr />
 
 			<!-- input-image -->
-			<a name="input-image"></a>
+			<a id="input-image"></a>
 			<h4><a href="#input-image"><code>&lt;input[type=image]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=image]&gt;</code> is a graphical submit button. Displays an image defined by the src attribute. The alt attribute displays if the image src is missing.
@@ -1077,7 +1077,7 @@
 			<hr />
 
 			<!-- input-month -->
-			<a name="input-month"></a>
+			<a id="input-month"></a>
 			<h4><a href="#input-month"><code>&lt;input[type=month]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=month]&gt;</code> is a control for entering a month and year, with no time zone.
@@ -1094,7 +1094,7 @@
 			<hr />
 
 			<!-- input-number -->
-			<a name="input-number"></a>
+			<a id="input-number"></a>
 			<h4><a href="#input-number"><code>&lt;input[type=number]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=number]&gt;</code> is a control for entering a number. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads.
@@ -1111,7 +1111,7 @@
 			<hr />
 
 			<!-- input-password -->
-			<a name="input-password"></a>
+			<a id="input-password"></a>
 			<h4><a href="#input-password"><code>&lt;input[type=password]&gt;</code></a></h4>
 			<p><code>&lt;input[type=password]&gt;</code> is a control for entering a password. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads.</p>
 			<details open>
@@ -1125,7 +1125,7 @@
 			<hr />
 
 			<!-- input-radio -->
-			<a name="input-radio"></a>
+			<a id="input-radio"></a>
 			<h4><a href="#input-radio"><code>&lt;input[type=radio]&gt;</code></a></h4>
 			<p><code>&lt;input[type=radio]&gt;</code> is a radio button, allowing a single value to be selected out of multiple choices with the same name value.</p>
 			<details open>
@@ -1148,7 +1148,7 @@
 			<hr />
 
 			<!-- input-range -->
-			<a name="input-range"></a>
+			<a id="input-range"></a>
 			<h4><a href="#input-range"><code>&lt;input[type=range]&gt;</code></a></h4>
 			<p><code>&lt;input[type=range]&gt;</code> is a control for entering a range. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads.</p>
 			<details open>
@@ -1162,7 +1162,7 @@
 			<hr />
 
 			<!-- input-search -->
-			<a name="input-search"></a>
+			<a id="input-search"></a>
 			<h4><a href="#input-search"><code>&lt;input[type=search]&gt;</code></a></h4>
 			<p><code>&lt;input[type=search]&gt;</code> is a single-line text field for entering search strings. Line-breaks are automatically removed from the input value. May include a delete icon in supporting browsers that can be used to clear the field. Displays a search icon instead of enter key on some devices with dynamic keypads.</p>
 			<details open>
@@ -1178,7 +1178,7 @@
 			<hr />
 			
 			<!-- input-submit -->
-			<a name="input-submit"></a>
+			<a id="input-submit"></a>
 			<h4><a href="#input-submit"><code>&lt;input[type=submit]&gt;</code></a></h4>
 			<p><code>&lt;input[type=submit]&gt;</code> is a button that submits the form.</p>
 			<details open>
@@ -1191,7 +1191,7 @@
 			<hr />
 
 			<!-- input-tel -->
-			<a name="input-tel"></a>
+			<a id="input-tel"></a>
 			<h4><a href="#input-tel"><code>&lt;input[type=tel]&gt;</code></a></h4>
 			<p><code>&lt;input[type=tel]&gt;</code> is acontrol for entering a telephone number. Displays a telephone keypad in some devices with dynamic keypads.</p>
 			<details open>
@@ -1205,7 +1205,7 @@
 			<hr />
 
 			<!-- input-text -->
-			<a name="input-text"></a>
+			<a id="input-text"></a>
 			<h4><a href="#input-text"><code>&lt;input[type=text]&gt;</code></a></h4>
 			<p><code>&lt;input[type=text]&gt;</code> is the default value. A single-line text field. Line-breaks are automatically removed from the input value.</p>
 			<details open>
@@ -1219,7 +1219,7 @@
 			<hr />
 
 			<!-- input-time -->
-			<a name="input-time"></a>
+			<a id="input-time"></a>
 			<h4><a href="#input-time"><code>&lt;input[type=time]&gt;</code></a></h4>
 			<p><code>&lt;input[type=time]&gt;</code> is a control for entering a time value with no time zone.</p>
 			<details open>
@@ -1233,7 +1233,7 @@
 			<hr />
 
 			<!-- input-url -->
-			<a name="input-url"></a>
+			<a id="input-url"></a>
 			<h4><a href="#input-url"><code>&lt;input[type=url]&gt;</code></a></h4>
 			<p><code>&lt;input[type=url]&gt;</code> is a field for entering a URL. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards.</p>
 			<details open>
@@ -1247,7 +1247,7 @@
 			<hr />
 
 			<!-- input-week -->
-			<a name="input-week"></a>
+			<a id="input-week"></a>
 			<h4><a href="#input-week"><code>&lt;input[type=week]&gt;</code></a></h4>
 			<p><code>&lt;input[type=week]&gt;</code> is a control for entering a date consisting of a week-year number and a week number with no time zone.</p>
 			<details open>
@@ -1261,7 +1261,7 @@
 			<hr />
 			
 			<!-- ins -->
-			<a name="ins"></a>
+			<a id="ins"></a>
 			<h4><a href="#ins"><code>&lt;ins&gt;</code></a></h4>
 			<p>The HTML <code>&lt;ins&gt;</code> element represents a range of text that has been added to a document.</p>
 			<details open>
@@ -1278,7 +1278,7 @@
 			<hr />
 
 			<!-- kbd -->
-			<a name="kbd"></a>
+			<a id="kbd"></a>
 			<h4><a href="#kbd"><code>&lt;kbd&gt;</code></a></h4>
 			<p>The HTML Keyboard Input element <code>&lt;kbd&gt;</code> represents a span of inline text denoting textual user input from a keyboard, voice input, or any other text entry device. By convention, the user agent defaults to rendering the contents of a <code>&lt;kbd&gt;</code> element using its default monospace font, although this is not mandated by the HTML standard.</p>
 			<details open>
@@ -1292,7 +1292,7 @@
 			<hr />
 
 			<!-- li -->
-			<a name="li"></a>
+			<a id="li"></a>
 			<h4><a href="#li"><code>&lt;li&gt;</code></a></h4>
 			<p>The HTML <code>&lt;li&gt;</code> element is used to represent an item in a list.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li">More at MDN →</a></p>
@@ -1342,7 +1342,7 @@
 			<hr />
 
 			<!-- main -->
-			<a name="main"></a>
+			<a id="main"></a>
 			<h4><a href="#main"><code>&lt;main&gt;</code></a></h4>
 			<p>The HTML <code>&lt;main&gt;</code> element represents the dominant content of the <code>&lt;body&gt;</code> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></p>
@@ -1354,12 +1354,12 @@
 			<hr />
 
 			<!-- map -->
-			<a name="map"></a>
-			<a name="area"></a>
-			<a name="area-bird-1"></a>
-			<a name="area-bird-2"></a>
-			<a name="area-bird-3"></a>
-			<a name="area-bench"></a>
+			<a id="map"></a>
+			<a id="area"></a>
+			<a id="area-bird-1"></a>
+			<a id="area-bird-2"></a>
+			<a id="area-bird-3"></a>
+			<a id="area-bench"></a>
 			<h4><a href="#map"><code>&lt;map&gt;</code></a></h4>
 			<p>Also: <a href="#area"><code>&lt;area&gt;</code></a>
 			<p>The HTML <code>&lt;map&gt;</code> element is used with <code>&lt;area&gt;</code> elements to define an image map (a clickable link area).</p>
@@ -1381,7 +1381,7 @@
 			<hr />
 
 			<!-- mark -->
-			<a name="mark"></a>
+			<a id="mark"></a>
 			<h4><a href="#mark"><code>&lt;mark&gt;</code></a></h4>
 			<p>The HTML Mark Text element <code>&lt;mark&gt;</code> represents text which is marked or highlighted for reference or notation purposes, due to the marked passage's relevance or importance in the enclosing context.</p>
 			<details open>
@@ -1394,7 +1394,7 @@
 			<hr />
 
 			<!-- meter -->
-			<a name="meter"></a>
+			<a id="meter"></a>
 			<h4><a href="#meter"><code>&lt;meter&gt;</code></a></h4>
 			<p>The HTML <code>&lt;meter&gt;</code> element represents either a scalar value within a known range or a fractional value.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter">More at MDN →</a></p>
@@ -1413,7 +1413,7 @@
 			<hr />
 
 			<!-- nav -->
-			<a name="nav"></a>
+			<a id="nav"></a>
 			<h4><a href="#nav"><code>&lt;nav&gt;</code></a></h4>
 			<p>The HTML <code>&lt;nav&gt;</code> element represents a section of a page whose purpose is to provide navigation links, either within the current document or to other documents. Common examples of navigation sections are menus, tables of contents, and indexes.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav">More at MDN →</a></p>
@@ -1435,7 +1435,7 @@
 			<hr />
 
 			<!-- ol -->
-			<a name="ol"></a>
+			<a id="ol"></a>
 			<h4><a href="#ol"><code>&lt;ol&gt;</code></a></h4>
 			<p>The HTML <code>&lt;ol&gt;</code> element represents an ordered list of items — typically rendered as a numbered list.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">More at MDN →</a></p>
@@ -1463,7 +1463,7 @@
 			<hr />
 
 			<!-- optgroup -->
-			<a name="optgroup"></a>
+			<a id="optgroup"></a>
 			<h4><a href="#optgroup"><code>&lt;optgroup&gt;</code></a></h4>
 			<p>The HTML <code>&lt;optgroup&gt;</code> element creates a grouping of options within a <code>&lt;select&gt;</code> element.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup">More at MDN →</a></p>
@@ -1489,7 +1489,7 @@
 			<hr />
 
 			<!-- option -->
-			<a name="option"></a>
+			<a id="option"></a>
 			<h4><a href="#option"><code>&lt;option&gt;</code></a></h4>
 			<p>The HTML <code>&lt;option&gt;</code> element is used to define an item contained in a <code>&lt;select&gt;</code>, an <code>&lt;optgroup&gt;</code>, or a <code>&lt;datalist&gt;</code> element. As such, <code>&lt;option&gt;</code> can represent menu items in popups and other lists of items in an HTML document.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option">More at MDN →</a></p>
@@ -1512,7 +1512,7 @@
 			<hr />
 
 			<!-- output -->
-			<a name="output"></a>
+			<a id="output"></a>
 			<h4><a href="#output"><code>&lt;output&gt;</code></a></h4>
 			<p>The HTML Output element <code>&lt;output&gt;</code> is a container element into which a site or app can inject the results of a calculation or the outcome of a user action.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output">More at MDN →</a></p>
@@ -1534,7 +1534,7 @@
 			<hr />
 
 			<!-- p -->
-			<a name="p"></a>
+			<a id="p"></a>
 			<h4><a href="#p"><code>&lt;p&gt;</code></a></h4>
 			<p>The HTML <code>&lt;p&gt;</code> element represents a paragraph.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p">More at MDN →</a></p>
@@ -1549,8 +1549,8 @@
 			<hr />
 
 			<!-- picture -->
-			<a name="picture"></a>
-			<a name="source"></a>
+			<a id="picture"></a>
+			<a id="source"></a>
 			<h4><a href="#picture"><code>&lt;picture&gt;</code></a></h4>
 			<p>Also: <a href="#source"><code>&lt;source&gt;</code></a>
 			<p>The HTML <code>&lt;picture&gt;</code> element contains zero or more <code>&lt;source&gt;</code> elements and one <code>&lt;img&gt;</code> element to offer alternative versions of an image for different display/device scenarios.</p>
@@ -1570,7 +1570,7 @@
 			<hr />
 
 			<!-- pre -->
-			<a name="pre"></a>
+			<a id="pre"></a>
 			<h4><a href="#pre"><code>&lt;pre&gt;</code></a></h4>
 			<p>The HTML <code>&lt;pre&gt;</code> element represents preformatted text which is to be presented exactly as written in the HTML file.</p>
 			<details open>
@@ -1584,7 +1584,7 @@
 			<hr />
 
 			<!-- progress -->
-			<a name="progress"></a>
+			<a id="progress"></a>
 			<h4><a href="#progress"><code>&lt;progress&gt;</code></a></h4>
 			<p>The HTML <code>&lt;progress&gt;</code> element displays an indicator showing the completion progress of a task, typically displayed as a progress bar.</p>
 			<p><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress">More at MDN →</a></p>
@@ -1599,7 +1599,7 @@
 			<hr />
 
 			<!-- q -->
-			<a name="q"></a>
+			<a id="q"></a>
 			<h4><a href="#q"><code>&lt;q&gt;</code></a></h4>
 			<p>The HTML <code>&lt;q&gt;</code> element indicates that the enclosed text is a short inline quotation. Most modern browsers implement this by surrounding the text in quotation marks.</p>
 			<details open>
@@ -1612,7 +1612,7 @@
 			<hr />
 
 			<!-- ruby -->
-			<a name="ruby"></a>
+			<a id="ruby"></a>
 			<h4><a href="#ruby"><code>&lt;ruby&gt;</code></a></h4>
 			<p>Also: <a href="#rp"><code>&lt;rp&gt;</code></a>,
 				<a href="#rt"><code>&lt;rt&gt;</code></a>, 
@@ -1629,7 +1629,7 @@
 			<hr />
 			
 			<!-- s -->
-			<a name="s"></a>
+			<a id="s"></a>
 			<h4><a href="#s"><code>&lt;s&gt;</code></a></h4>
 			<p>The HTML <code>&lt;s&gt;</code> element renders text with a strikethrough, or a line through it. Use the <code>&lt;s&gt;</code> element to represent things that are no longer relevant or no longer accurate. However, <code>&lt;s&gt;</code> is not appropriate when indicating document edits; for that, use the <code>&lt;del&gt;</code> and <code>&lt;ins&gt;</code> elements, as appropriate.</p>
 			<details open>
@@ -1642,7 +1642,7 @@
 			<hr />
 
 			<!-- samp -->
-			<a name="samp"></a>
+			<a id="samp"></a>
 			<h4><a href="#samp"><code>&lt;samp&gt;</code></a></h4>
 			<p>The HTML Sample Element <code>&lt;samp&gt;</code> is used to enclose inline text which represents sample (or quoted) output from a computer program.</p>
 			<details open>
@@ -1656,7 +1656,7 @@
 			<hr />
 
 			<!-- section -->
-			<a name="section"></a>
+			<a id="section"></a>
 			<h4><a href="#section"><code>&lt;section&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;section&gt;</code> element represents a standalone section — which doesn't have a more specific semantic element to represent it — contained within an HTML document.
@@ -1672,7 +1672,7 @@
 			<hr />
 
 			<!-- select -->
-			<a name="select"></a>
+			<a id="select"></a>
 			<h4><a href="#select"><code>&lt;select&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;select&gt;</code> element represents a control that provides a menu of options.
@@ -1697,7 +1697,7 @@
 			<hr />
 
 			<!-- small -->
-			<a name="small"></a>
+			<a id="small"></a>
 			<h4><a href="#small"><code>&lt;small&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;small&gt;</code> element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small.
@@ -1713,7 +1713,7 @@
 			<hr />
 
 			<!-- span -->
-			<a name="span"></a>
+			<a id="span"></a>
 			<h4><a href="#span"><code>&lt;span&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;span&gt;</code> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang.
@@ -1729,7 +1729,7 @@
 			<hr />
 
 			<!-- strong -->
-			<a name="strong"></a>
+			<a id="strong"></a>
 			<h4><a href="#strong"><code>&lt;strong&gt;</code></a></h4>
 			<p>
 				The HTML Strong Importance Element <code>&lt;strong&gt;</code> indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type.
@@ -1745,7 +1745,7 @@
 			<hr />
 
 			<!-- sub -->
-			<a name="sub"></a>
+			<a id="sub"></a>
 			<h4><a href="#sub"><code>&lt;sub&gt;</code></a></h4>
 			<p>
 				The HTML Subscript element (<code>&lt;sub&gt;</code>) specifies inline text which should be displayed as subscript for solely typographical reasons.
@@ -1761,7 +1761,7 @@
 			<hr />
 
 			<!-- sup -->
-			<a name="sup"></a>
+			<a id="sup"></a>
 			<h4><a href="#sup"><code>&lt;sup&gt;</code></a></h4>
 			<p>
 				The HTML Superscript element (<code>&lt;sup&gt;</code>) specifies inline text which is to be displayed as superscript for solely typographical reasons.
@@ -1783,16 +1783,16 @@
 			<!-- th -->
 			<!-- thead -->
 			<!-- tr -->
-			<a name="table"></a>
-			<a name="caption"></a>
-			<a name="col"></a>
-			<a name="colgroup"></a>
-			<a name="tbody"></a>
-			<a name="td"></a>
-			<a name="tfoot"></a>
-			<a name="th"></a>
-			<a name="thead"></a>
-			<a name="tr"></a>
+			<a id="table"></a>
+			<a id="caption"></a>
+			<a id="col"></a>
+			<a id="colgroup"></a>
+			<a id="tbody"></a>
+			<a id="td"></a>
+			<a id="tfoot"></a>
+			<a id="th"></a>
+			<a id="thead"></a>
+			<a id="tr"></a>
 			<h4><a href="#table"><code>&lt;table&gt;</code></a></h4>
 			<p>Also: <a href="#caption"><code>&lt;caption&gt;</code></a>,
 				<a href="#col"><code>&lt;col&gt;</code></a>, 
@@ -1856,7 +1856,7 @@
 			<hr />
 
 			<!-- time -->
-			<a name="time"></a>
+			<a id="time"></a>
 			<h4><a href="#time"><code>&lt;time&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;time&gt;</code> element represents a specific period in time.
@@ -1872,7 +1872,7 @@
 			<hr />
 
 			<!-- u -->
-			<a name="u"></a>
+			<a id="u"></a>
 			<h4><a href="#u"><code>&lt;u&gt;</code></a></h4>
 			<p>
 				The HTML Unarticulated Annotation Element (<code>&lt;u&gt;</code>) represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation.
@@ -1888,7 +1888,7 @@
 			<hr />
 			
 			<!-- ul -->
-			<a name="ul"></a>
+			<a id="ul"></a>
 			<h4><a href="#ul"><code>&lt;ul&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;ul&gt;</code> element represents an unordered list of items, typically rendered as a bulleted list.
@@ -1918,7 +1918,7 @@
 			<hr />
 
 			<!-- var -->
-			<a name="var"></a>
+			<a id="var"></a>
 			<h4><a href="#var"><code>&lt;var&gt;</code></a></h4>
 			<p>
 				The HTML Variable element (<code>&lt;var&gt;</code>) represents the name of a variable in a mathematical expression or a programming context.
@@ -1934,7 +1934,7 @@
 			<hr />
 
 			<!-- video -->
-			<a name="video"></a>
+			<a id="video"></a>
 			<h4><a href="#video"><code>&lt;video&gt;</code></a></h4>
 			<p>
 				The HTML Video element <code>&lt;video&gt;</code> embeds a media player which supports video playback into the document. You can use <code>&lt;video&gt;</code> for audio content as well, but the <code>&lt;audio&gt;</code> element may provide a more appropriate user experience.
@@ -1957,7 +1957,7 @@
 			<hr />
 
 			<!-- wbr -->
-			<a name="wbr"></a>
+			<a id="wbr"></a>
 			<h4><a href="#wbr"><code>&lt;wbr&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;wbr&gt;</code> element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.
@@ -1974,7 +1974,7 @@
 			</details>
 			<hr />
 
-			<a name="omitted-elements"></a>
+			<a id="omitted-elements"></a>
 			<h3>Omitted Elements</h3>
 			<p>Reasonable.html omits a handful of HTML elements, the reason for each omission is stated here. Mostly though, since it was built to test CSS rules, elements which need no styling were not included.</p>
 			<p>If you disagree with any of the omissions, please file an issue and make your case.</p>
@@ -2001,7 +2001,7 @@
 		<hr />
 		<section>
 			
-			<a name="acknowledgements"></a>
+			<a id="acknowledgements"></a>
 			<h2>👏 Acknowledgements, Credits, and Thanks</h2>
 
 			<h3>MDN Web Docs</h3>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
 				<p>Like everything in life, it couldn't exist without the help and generosity of others, find a <a href="#acknowledgements">full list of acknowledgements here.</a></p>
 			</article>
 		</main>
-		<hr />
+		<hr>
 		
 		<!-- elements -->
 		<section>
@@ -48,10 +48,10 @@
 
 			<p>There are also a handful of ommitted HTML elements, which are <a href="#omitted-elements">detailed here</a>.</p>
 
-			<hr />
+			<hr>
 			<form id="go-to-element" onsubmit="elementNavigationHandler(event);">
 				<label for="element-navigation">Jump to Element</label>
-				<br />
+				<br>
 				<select name="element-navigation" id="element-navigation">
 						<option value="example-html-elements" label="Element"></option>
 						<option value="a">a</option>
@@ -149,14 +149,14 @@
 				<button id="go-to-element-submit" type="submit" >Go →</button>
 			</form>
 
-			<hr />
+			<hr>
 
 			<!-- a -->
 			<a id="a"></a>
 			<h4><a href="#a"><code>&lt;a&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;a&gt;</code> element (or anchor element), with its href attribute, creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
-				<br /><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">More at MDN →</a>
+				<br><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
@@ -164,7 +164,7 @@
 					<p>A paragraph of text which contains <a href="">an anchor element</a>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- abbr -->
 			<a id="abbr"></a>
@@ -179,26 +179,26 @@
 					<p>A paragraph of text which contains an abbreviation element for the acronym <abbr title="light amplification by stimulated emission of radiation">laser</abbr>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- address -->
 			<a id="address"></a>
 			<h4><a href="#address"><code>&lt;address&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;address&gt;</code> element indicates that the enclosed HTML provides contact information for a person or people, or for an organization.
-				<br /><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address">More at MDN →</a>
+				<br><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
 					<address>
-						123 Address St<br />
-						Example Town, CA 12345<br />
+						123 Address St<br>
+						Example Town, CA 12345<br>
 						USA
 					</address>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- article -->
 			<a id="article"></a>
@@ -218,14 +218,14 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- aside -->
 			<a id="aside"></a>
 			<h4><a href="#aside"><code>&lt;aside&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;aside&gt;</code> element represents a portion of a document whose content is only indirectly related to the document's main content.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside">More at MDN →</a>
 			</p>
 			<details open>
@@ -236,14 +236,14 @@
 					<p>Returning to the topic of dogs: to be considered a pack, three or more adult dogs are required.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- audio -->
 			<a id="audio"></a>
 			<h4><a href="#audio"><code>&lt;audio&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;audio&gt;</code> element is used to embed sound content in documents. It may contain one or more audio sources, represented using the <code>src</code> attribute or the <code>&lt;source&gt;</code> element: the browser will choose the most suitable one. It can also be the destination for streamed media, using a MediaStream.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio">More at MDN →</a>
 			</p>
 			<details open>
@@ -257,14 +257,14 @@
 					</figure>		
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- b -->
 			<a id="b"></a>
 			<h4><a href="#b"><code>&lt;b&gt;</code></a></h4>
 			<p>
 				The HTML Bring Attention To element <code>&lt;b&gt;</code> is used to draw the reader's attention to the element's contents, which are not otherwise granted special importance.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b">More at MDN →</a>
 			</p>
 			<details open>
@@ -273,14 +273,14 @@
 					<p>A paragraph of text which contains <b>a bring attention to element</b>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- bdi -->
 			<a id="bdi"></a>
 			<h4><a href="#bdi"><code>&lt;bdi&gt;</code></a></h4>
 			<p>
 				The HTML Bidirectional Isolate element <code>&lt;bdi&gt;</code> tells the browser's bidirectional algorithm to treat the text it contains in isolation from its surrounding text.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi">More at MDN →</a>
 			</p>
 			<details open>
@@ -290,14 +290,14 @@
 					<p>The Arabic word for Internet is <bdi>الإنترنت</bdi>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- bdo -->
 			<a id="bdo"></a>
 			<h4><a href="#bdo"><code>&lt;bdo&gt;</code></a></h4>
 			<p>
 				The HTML Bidirectional Text Override element <code>&lt;bdo&gt;</code> overrides the current directionality of text, so that the text within is rendered in a different direction.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo">More at MDN →</a>
 			</p>
 			<details open>
@@ -307,14 +307,14 @@
 					<p>A paragraph of text which contains a right-to-left <bdo dir="rtl">bidirectional text override element</bdo>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- blockquote -->
 			<a id="blockquote"></a>
 			<h4><a href="#blockquote"><code>&lt;blockquote&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;blockquote&gt;</code>  Element (or HTML Block Quotation Element) indicates that the enclosed text is an extended quotation. Usually, this is rendered visually by indentation (see Notes for how to change it). A URL for the source of the quotation may be given using the cite attribute, while a text representation of the source can be given using the <code>&lt;cite&gt;</code> element.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote">More at MDN →</a>
 			</p>
 			<details open>
@@ -328,14 +328,14 @@
 					</blockquote>		
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- button -->
 			<a id="button"></a>
 			<h4><a href="#button"><code>&lt;button&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;button&gt;</code> element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button">More at MDN →</a>
 			</p>
 			<details open>
@@ -344,14 +344,14 @@
 					<button>A button element</button>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- cite -->
 			<a id="cite"></a>
 			<h4><a href="#cite"><code>&lt;cite&gt;</code></a></h4>
 			<p>
 				The HTML Citation element <code>&lt;cite&gt;</code> is used to describe a reference to a cited creative work, and must include the title of that work.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite">More at MDN →</a>
 			</p>
 			<details open>
@@ -366,14 +366,14 @@
 					</blockquote>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- code -->
 			<a id="code"></a>
 			<h4><a href="#code"><code>&lt;code&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;code&gt;</code> element displays its contents styled in a fashion intended to indicate that the text is a short fragment of computer code. By default, the content text is displayed using the user agent's default monospace font.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code">More at MDN →</a>
 			</p>
 			<details open>
@@ -383,14 +383,14 @@
 					
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- data -->
 			<a id="data"></a>
 			<h4><a href="#data"><code>&lt;data&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;data&gt;</code> element links a given content with a machine-readable translation. If the content is time- or date-related, the <code>&lt;time&gt;</code> element must be used.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/data">More at MDN →</a>
 			</p>
 			<details open>
@@ -406,21 +406,21 @@
 					</ol>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- datalist -->
 			<a id="datalist"></a>
 			<h4><a href="#datalist"><code>&lt;datalist&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;datalist&gt;</code> element contains a set of <code>&lt;option&gt;</code> elements that represent the permissible or recommended options available to choose from within other controls.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
 					<label for="beverage-choice-input">Favorite hot beverage:</label>
-					<input list="beverage-choice" id="beverage-choice-input" name="beverage-choice" />
+					<input list="beverage-choice" id="beverage-choice-input" name="beverage-choice">
 					<datalist id="beverage-choice">
 						<option value="Aleberry">
 						<option value="Anijsmelk">
@@ -456,14 +456,14 @@
 					</datalist>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- del -->
 			<a id="del"></a>
 			<h4><a href="#del"><code>&lt;del&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;del&gt;</code> element represents a range of text that has been deleted from a document.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del">More at MDN →</a>
 			</p>
 			<details open>
@@ -476,7 +476,7 @@
 					<p>A paragraph of text following an <code>&lt;del&gt;</code> element.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- details -->
 			<a id="details"></a>
@@ -485,7 +485,7 @@
 			<p>Also: <a href="#summary"><code>&lt;summary&gt;</code></a>
 			<p>
 				The HTML Details Element <code>&lt;details&gt;</code> creates a disclosure widget in which information is visible only when the widget is toggled into an "open" state.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details">More at MDN →</a>
 			</p>
 			<details open>
@@ -497,14 +497,14 @@
 					</details>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- dfn -->
 			<a id="dfn"></a>
 			<h4><a href="#dfn"><code>&lt;dfn&gt;</code></a></h4>
 			<p>
 				The HTML Definition element (<code>&lt;dfn&gt;</code>) is used to indicate the term being defined within the context of a definition phrase or sentence. The <code>&lt;p&gt;</code> element, the <code>&lt;dt&gt;</code>/<code>&lt;dd&gt;</code> pairing, or the <code>&lt;section&gt;</code> element which is the nearest ancestor of the <code>&lt;dfn&gt;</code> is considered to be the definition of the term.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn">More at MDN →</a>
 			</p>
 			<details open>
@@ -513,14 +513,14 @@
 					<p>A <dfn id="def-validator">human</dfn> is a person; a human being, distinct from animals, aliens, and especially charming, life-like, humanoid robots.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- div -->
 			<a id="div"></a>
 			<h4><a href="#div"><code>&lt;div&gt;</code></a></h4>
 			<p>
 				The HTML Content Division element (<code>&lt;div&gt;</code>) is the generic container for flow content. It has no effect on the content or layout until styled using CSS.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div">More at MDN →</a>
 			</p>
 			<details open>
@@ -531,7 +531,7 @@
 					<p>A paragraph of text following a div element.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- dl -->
 			<a id="dl"></a>
@@ -542,7 +542,7 @@
 				<a href="#dt"><code>&lt;dt&gt;</code></a></p>
 			<p>
 				The HTML <code>&lt;dl&gt;</code> element represents a description list. The element encloses a list of groups of terms (specified using the <code>&lt;dt&gt;</code> element) and descriptions (provided by <code>&lt;dd&gt;</code> elements). Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl">More at MDN →</a>
 			</p>
 			<details open>
@@ -585,14 +585,14 @@
 					</dl>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- em -->
 			<a id="em"></a>
 			<h4><a href="#em"><code>&lt;em&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;em&gt;</code> element marks text that has stress emphasis. The <code>&lt;em&gt;</code> element can be nested, with each level of nesting indicating a greater degree of emphasis.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em">More at MDN →</a>
 			</p>
 			<details open>
@@ -602,7 +602,7 @@
 				</section>
 			</details>
 			<aside></aside>
-			<hr />
+			<hr>
 
 			<!-- fieldset -->
 			<!-- label -->
@@ -614,7 +614,7 @@
 			<p>Also: <a href="#label"><code>&lt;label&gt;</code></a>, <a href="#legend"><code>&lt;legend&gt;</code></a>
 			<p>
 				The HTML <code>&lt;fieldset&gt;</code> element is used to group several controls as well as labels (<code>&lt;label&gt;</code>) within a web form.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset">More at MDN →</a>
 			</p>
 			<details open>
@@ -623,25 +623,25 @@
 						<fieldset>
 							<legend>Favorite moon phase</legend>
 							<label for="new-moon"><input type="radio" id="new-moon" name="moon-phase">🌑 New Moon</label>
-							<br />
+							<br>
 							
 							<label for="waxing-crescent"><input type="radio" id="waxing-crescent" name="moon-phase">🌒 Waxing Crescent</label>
-							<br />
+							<br>
 							
 							<label for="first-quarter"><input type="radio" id="first-quarter" name="moon-phase">🌓 First Quarter</label>
-							<br />
+							<br>
 
 							<label for="waxing-gibbous"><input type="radio" id="waxing-gibbous" name="moon-phase">🌔 Waxing Gibbous</label>
-							<br />
+							<br>
 
 							<label for="full-moon"><input type="radio" id="full-moon" name="moon-phase">🌕 Full Moon</label>
-							<br />
+							<br>
 
 							<label for="waning-gibbous"><input type="radio" id="waning-gibbous" name="moon-phase">🌖 Waning Gibbous</label>
-							<br />
+							<br>
 
 							<label for="last-quarter"><input type="radio" id="last-quarter" name="moon-phase">🌗 Last Quarter</label>
-							<br />
+							<br>
 
 							<label for="waning-crescent"><input type="radio" id="waning-crescent" name="moon-phase">🌘 Waning Crescent</label>
 						</fieldset>
@@ -656,7 +656,7 @@
 						</fieldset>
 					</form>				  
 			</details>
-			<hr />
+			<hr>
 
 			<!-- figure -->
 			<a id="figure"></a>
@@ -666,7 +666,7 @@
 			<p>Also: <a href="#figcaption"><code>&lt;figcaption&gt;</code></a>, <a href="#img"><code>&lt;img&gt;</code></a>
 			<p>
 				The HTML <code>&lt;figure&gt;</code> (Figure With Optional Caption) element represents self-contained content, potentially with an optional caption, which is specified using the (<code>&lt;figcaption&gt;</code>) element.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure">More at MDN →</a>
 			</p>
 			<details open>
@@ -678,14 +678,14 @@
 					</figure>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- footer -->
 			<a id="footer"></a>
 			<h4><a href="#footer"><code>&lt;footer&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;footer&gt;</code> element represents a footer for its nearest sectioning content or sectioning root element. A footer typically contains information about the author of the section, copyright data or links to related documents.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer">More at MDN →</a>
 			</p>
 			<details open>
@@ -694,7 +694,7 @@
 					<footer>A footer element within its containing section element.</footer>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- form -->
 			<a id="form"></a>
@@ -703,7 +703,7 @@
 			<p>Also: <a href="#textarea"><code>&lt;textarea&gt;</code></a>
 			<p>
 				The HTML <code>&lt;form&gt;</code> element represents a document section containing interactive controls for submitting information.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form">More at MDN →</a>
 			</p>
 			<details open>
@@ -713,11 +713,11 @@
 						<legend>Send a message to a mythical water creature</legend>
 						<ol>
 							<li>
-								<label for="name">Your Name</label><br />
-								<input id="name" required />
+								<label for="name">Your Name</label><br>
+								<input id="name" required>
 							</li>
 							<li>
-								<label for="message">Message</label><br />
+								<label for="message">Message</label><br>
 								<textarea id="message" required placeholder="Ahoy!"></textarea>
 							</li>
 						
@@ -725,13 +725,13 @@
 								<fieldset>
 									<legend>Mythical water creature</legend>
 
-									<label><input type="radio" name="mythical-sea-creature" required />🇳🇴 Kraken (<a href="https://en.wikipedia.org/wiki/Kraken">more info</a>)</label><br />
+									<label><input type="radio" name="mythical-sea-creature" required>🇳🇴 Kraken (<a href="https://en.wikipedia.org/wiki/Kraken">more info</a>)</label><br>
 									
-									<label><input type="radio" name="mythical-sea-creature" />🏴󠁧󠁢󠁳󠁣󠁴󠁿 Loch Ness Monster (<a href="https://en.wikipedia.org/wiki/Loch_Ness_Monster">more info</a>)</label><br />
+									<label><input type="radio" name="mythical-sea-creature">🏴󠁧󠁢󠁳󠁣󠁴󠁿 Loch Ness Monster (<a href="https://en.wikipedia.org/wiki/Loch_Ness_Monster">more info</a>)</label><br>
 
-									<label><input type="radio" name="mythical-sea-creature" />🇨🇦 Ogopogo (<a href="https://en.wikipedia.org/wiki/Ogopogo">more info</a>)</label><br />
+									<label><input type="radio" name="mythical-sea-creature">🇨🇦 Ogopogo (<a href="https://en.wikipedia.org/wiki/Ogopogo">more info</a>)</label><br>
 
-									<label><input type="radio" name="mythical-sea-creature" />🇺🇸 Champ (<a href="https://en.wikipedia.org/wiki/Champ_(folklore)">more info</a>)</label><br />
+									<label><input type="radio" name="mythical-sea-creature">🇺🇸 Champ (<a href="https://en.wikipedia.org/wiki/Champ_(folklore)">more info</a>)</label><br>
 								</fieldset>
 							</li>
 						</ol>
@@ -739,14 +739,14 @@
 						<button id="send-message-submit" type="submit" >Send Message →</button>
 				  </form>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h1 -->
 			<a id="h1"></a>
 			<h4><a href="#h1"><code>&lt;h1&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h1&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1">More at MDN →</a>
 			</p>
 			<details open>
@@ -756,14 +756,14 @@
 					<p>A paragraph of text following the h1 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h2 -->
 			<a id="h2"></a>
 			<h4><a href="#h2"><code>&lt;h2&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h2&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2">More at MDN →</a>
 			</p>
 			<details open>
@@ -773,14 +773,14 @@
 					<p>A paragraph of text following the h2 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h3 -->
 			<a id="h3"></a>
 			<h4><a href="#h3"><code>&lt;h3&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h3&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3">More at MDN →</a>
 			</p>
 			<details open>
@@ -790,14 +790,14 @@
 					<p>A paragraph of text following the h3 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h4 -->
 			<a id="h4"></a>
 			<h4><a href="#h4"><code>&lt;h4&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h4&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4">More at MDN →</a>
 			</p>
 			<details open>
@@ -807,14 +807,14 @@
 					<p>A paragraph of text following the h4 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h5 -->
 			<a id="h5"></a>
 			<h4><a href="#h5"><code>&lt;h5&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h5&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5">More at MDN →</a>
 			</p>
 			<details open>
@@ -824,14 +824,14 @@
 					<p>A paragraph of text following the h5 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- h6 -->
 			<a id="h6"></a>
 			<h4><a href="#h6"><code>&lt;h6&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;h6&gt;</code> elements represent six levels of section headings. <code>&lt;h1&gt;</code> is the highest section level and <code>&lt;h6&gt;</code> is the lowest.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6">More at MDN →</a>
 			</p>
 			<details open>
@@ -841,14 +841,14 @@
 					<p>A paragraph of text following the h6 section heading.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- header -->
 			<a id="header"></a>
 			<h4><a href="#header"><code>&lt;header&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;header&gt;</code> element represents introductory content, typically a group of introductory or navigational aids. It may contain some heading elements but also a logo, a search form, an author name, and other elements.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header">More at MDN →</a>
 			</p>
 			<details open>
@@ -857,14 +857,14 @@
 					<footer>A header element within its containing section element.</footer>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- hgroup -->
 			<a id="hgroup"></a>
 			<h4><a href="#hgroup"><code>&lt;hgroup&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;hgroup&gt;</code> element represents a multi-level heading for a section of a document. It groups a set of <code>&lt;h1&gt; - &lt;h6&gt;</code> elements.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup">More at MDN →</a>
 			</p>
 			<details open>
@@ -877,32 +877,32 @@
 					<p>A paragraph of text following an hgroup element.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- hr -->
 			<a id="hr"></a>
 			<h4><a href="#hr"><code>&lt;hr&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;hr&gt;</code> element represents a thematic break between paragraph-level elements: for example, a change of scene in a story, or a shift of topic within a section.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
 					<p>A paragraph of text preceeding an <code>&lt;hr&gt;</code> element.</p>
-					<hr />
+					<hr>
 					<p>A paragraph of text following an <code>&lt;hr&gt;</code> element.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- i -->
 			<a id="i"></a>
 			<h4><a href="#i"><code>&lt;i&gt;</code></a></h4>
 			<p>
 				The HTML Interesting Text element <code>&lt;i&gt;</code> represents a range of text that is set off from the normal text for some reason.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i">More at MDN →</a>
 			</p>
 			<details open>
@@ -911,14 +911,14 @@
 					<p>A paragraph of text which contains <i>an interesting text element</i>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- iframe -->
 			<a id="iframe"></a>
 			<h4><a href="#iframe"><code>&lt;iframe&gt;</code></a></h4>
 			<p>
 				The HTML Inline Frame element (<code>&lt;iframe&gt;</code>) represents a nested browsing context, embedding another HTML page into the current one.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe">More at MDN →</a>
 			</p>
 			<details open>
@@ -934,7 +934,7 @@
 					<p>A paragraph of text following an <code>&lt;iframe&gt;</code> element.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<h3>HTML Input Element Types</h3>
 			<p>The HTML <code>&lt;input&gt;</code> element is used to create interactive controls for web-based forms in order to accept data from the user; a wide variety of types of input data and control widgets are available, depending on the device and user agent.</p>
@@ -944,58 +944,58 @@
 			<h4><a href="#input-button"><code>&lt;input[type=button]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=button]&gt;</code> is a push button with no default behavior displaying the value of the value attribute, empty by default.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/button">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<label for="input-type-button">Input Type=Button</label><br />
-					<input type="button" id="input-type-button" name="input-type-button" value="BUTTON" />
+					<label for="input-type-button">Input Type=Button</label><br>
+					<input type="button" id="input-type-button" name="input-type-button" value="BUTTON">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-checkbox -->
 			<a id="input-checkbox"></a>
 			<h4><a href="#input-checkbox"><code>&lt;input[type=checkbox]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=checkbox]&gt;</code> is a check box allowing single values to be selected/deselected.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<input type="checkbox" id="input-type-checkbox" name="input-type-checkbox" value="Checkbox" />
+					<input type="checkbox" id="input-type-checkbox" name="input-type-checkbox" value="Checkbox">
 					<label for="input-type-checkbox">Input Type=Checkbox</label> 
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-color -->
 			<a id="input-color"></a>
 			<h4><a href="#input-color"><code>&lt;input[type=color]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=color]&gt;</code> is a control for specifying a color; opening a color picker when active in supporting browsers.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color">More at MDN →</a>
 			</p>
 			<details open>
 				<summary>Example</summary>
 				<section>
-					<input type="color" id="input-type-color" name="input-type-color" value="#990000" />
+					<input type="color" id="input-type-color" name="input-type-color" value="#990000">
 					<label for="input-type-color">Input Type=color</label> 
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-date -->
 			<a id="input-date"></a>
 			<h4><a href="#input-date"><code>&lt;input[type=date]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=date]&gt;</code> is a control for entering a date (year, month, and day, with no time). Opens a date picker or numeric wheels for year, month, day when active in supporting browsers.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date">More at MDN →</a>
 			</p>
 			<details open>
@@ -1006,14 +1006,14 @@
 				</section>
 			</details>
 			<aside></aside>
-			<hr />
+			<hr>
 
 			<!-- input-datetime-local -->
 			<a id="input-datetime-local"></a>
 			<h4><a href="#input-datetime-local"><code>&lt;input[type=datetime-local]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=datetime-local]&gt;</code> is a control for entering a date and time, with no time zone. Opens a date picker or numeric wheels for date- and time-components when active in supporting browsers.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local">More at MDN →</a>
 			</p>
 			<details open>
@@ -1023,14 +1023,14 @@
 					<input type="datetime-local" id="input-type-datetime-local" name="input-type-datetime-local" min="2001-01-01T00:00:00" max="2020-01-01T23:59:59">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-email -->
 			<a id="input-email"></a>
 			<h4><a href="#input-email"><code>&lt;input[type=email]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=email]&gt;</code> is a field for editing an email address. Looks like a text input, but has validation parameters and relevant keyboard in supporting browsers and devices with dynamic keyboards.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email">More at MDN →</a>
 			</p>
 			<details open>
@@ -1040,14 +1040,14 @@
 					<input type="email" id="input-type-email" name="input-type-email" required>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-file -->
 			<a id="input-file"></a>
 			<h4><a href="#input-file"><code>&lt;input[type=file]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=file]&gt;</code> is a control that lets the user select a file. Use the accept attribute to define the types of files that the control can select.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file">More at MDN →</a>
 			</p>
 			<details open>
@@ -1057,14 +1057,14 @@
 					<input type="file" id="input-type-file" name="input-type-file" accept="image/png, image/jpeg">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-image -->
 			<a id="input-image"></a>
 			<h4><a href="#input-image"><code>&lt;input[type=image]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=image]&gt;</code> is a graphical submit button. Displays an image defined by the src attribute. The alt attribute displays if the image src is missing.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image">More at MDN →</a>
 			</p>
 			<details open>
@@ -1074,14 +1074,14 @@
 					<input type="image" id="input-type-image" alt="Image Button" src="/media/examples/login-button.png">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-month -->
 			<a id="input-month"></a>
 			<h4><a href="#input-month"><code>&lt;input[type=month]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=month]&gt;</code> is a control for entering a month and year, with no time zone.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/month">More at MDN →</a>
 			</p>
 			<details open>
@@ -1091,14 +1091,14 @@
 					<input type="month" id="input-type-month" name="input-type-month">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-number -->
 			<a id="input-number"></a>
 			<h4><a href="#input-number"><code>&lt;input[type=number]&gt;</code></a></h4>
 			<p>
 				<code>&lt;input[type=number]&gt;</code> is a control for entering a number. Displays a spinner and adds default validation when supported. Displays a numeric keypad in some devices with dynamic keypads.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number">More at MDN →</a>
 			</p>
 			<details open>
@@ -1108,7 +1108,7 @@
 					<input type="number" id="input-type-number" name="input-type-number" min="1" max="100">
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- input-password -->
 			<a id="input-password"></a>
@@ -1122,7 +1122,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/password">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-radio -->
 			<a id="input-radio"></a>
@@ -1132,20 +1132,20 @@
 				<summary>Example</summary>
 				<section>
 					<label for="input-type-radio-1"><input type="radio" id="input-type-radio-1" name="input-type-radio"> Input Type=radio</label>					
-					<br />
+					<br>
 
 					<label for="input-type-radio-2"><input type="radio" id="input-type-radio-2" name="input-type-radio" required> Input Type=radio</label>
-					<br />
+					<br>
 
 					<label for="input-type-radio-3"><input type="radio" id="input-type-radio-3" name="input-type-radio" required> Input Type=radio</label>
-					<br />
+					<br>
 
 					<label for="input-type-radio-4"><input type="radio" id="input-type-radio-4" name="input-type-radio" required> Input Type=radio</label>
 					
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-range -->
 			<a id="input-range"></a>
@@ -1159,7 +1159,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-search -->
 			<a id="input-search"></a>
@@ -1169,13 +1169,13 @@
 				<summary>Example</summary>
 				<section>
 					<form role="search">
-						<label for="input-type-search">Input Type=search</label><br/>
+						<label for="input-type-search">Input Type=search</label><br>
 						<input type="search" id="input-type-search" name="input-type-search"  aria-label="Search input">
 					</form>
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search">More at MDN →</a></aside>
-			<hr />
+			<hr>
 			
 			<!-- input-submit -->
 			<a id="input-submit"></a>
@@ -1188,7 +1188,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-tel -->
 			<a id="input-tel"></a>
@@ -1202,7 +1202,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/tel">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-text -->
 			<a id="input-text"></a>
@@ -1216,7 +1216,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-time -->
 			<a id="input-time"></a>
@@ -1230,7 +1230,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-url -->
 			<a id="input-url"></a>
@@ -1244,7 +1244,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/url">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- input-week -->
 			<a id="input-week"></a>
@@ -1258,7 +1258,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/week">More at MDN →</a></aside>
-			<hr />
+			<hr>
 			
 			<!-- ins -->
 			<a id="ins"></a>
@@ -1275,7 +1275,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- kbd -->
 			<a id="kbd"></a>
@@ -1289,7 +1289,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- li -->
 			<a id="li"></a>
@@ -1339,7 +1339,7 @@
 				</ul>				
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- main -->
 			<a id="main"></a>
@@ -1351,7 +1351,7 @@
 				<p>Most of this document is in a <code>&lt;main&gt;</code> element.  Only one visible <code>&lt;main&gt;</code> element is allowed.</p>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- map -->
 			<a id="map"></a>
@@ -1372,13 +1372,13 @@
 						<area shape="rect" coords="184,56,192,64" alt="Bird 3" href="#area-bird-3">
 						<area shape="rect" coords="140,116,178,138" alt="Bench" href="#area-bench">
 					</map>
-					<img width="320" usemap="#areamap" src="./images/undraw-through-the-park.svg" alt="Through the Park" />
+					<img width="320" usemap="#areamap" src="./images/undraw-through-the-park.svg" alt="Through the Park">
 					<figcaption>Illustration by <a href="https://twitter.com/undraw_co">Katerina Limpitsouni</a> on <a href="https://undraw.co">unDraw</a>.
 					</figcaption>
 				</figure>	
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/map">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- mark -->
 			<a id="mark"></a>
@@ -1391,7 +1391,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- meter -->
 			<a id="meter"></a>
@@ -1404,13 +1404,13 @@
 					<h5>Orion III</h5>
 					<label for="engine-one-fuel-level">Engine 1 fuel level</label><meter id="engine-one-fuel-level" min="0" max="100" low="33" high="66" optimum="80" value="87">at 87/100
 					</meter>
-					<br />
+					<br>
 					<label for="engine-two-fuel-level">Engine 2 fuel level</label><meter id="engine-two-fuel-level" min="0" max="100" low="33" high="66" optimum="80" value="64">at 64/100
 					</meter>
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- nav -->
 			<a id="nav"></a>
@@ -1432,7 +1432,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- ol -->
 			<a id="ol"></a>
@@ -1460,7 +1460,7 @@
 				</ol>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- optgroup -->
 			<a id="optgroup"></a>
@@ -1486,7 +1486,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- option -->
 			<a id="option"></a>
@@ -1509,7 +1509,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- output -->
 			<a id="output"></a>
@@ -1522,16 +1522,16 @@
 					<form oninput="result.value=(formexamplename.value.trim().split(' ').length)" id="form-example">
 						<fieldset>
 							<legend>Word counter</legend>
-							<label for="formexamplename">Your words:</label><br />
+							<label for="formexamplename">Your words:</label><br>
 							<textarea name="formexamplename" id="formexamplename" required></textarea>
-							<br />
+							<br>
 							You have typed <output name="result" for="formexamplename">0</output> words.
 						</fieldset>
 					</form>
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- p -->
 			<a id="p"></a>
@@ -1546,7 +1546,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- picture -->
 			<a id="picture"></a>
@@ -1567,7 +1567,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- pre -->
 			<a id="pre"></a>
@@ -1581,7 +1581,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- progress -->
 			<a id="progress"></a>
@@ -1596,7 +1596,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- q -->
 			<a id="q"></a>
@@ -1609,7 +1609,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- ruby -->
 			<a id="ruby"></a>
@@ -1626,7 +1626,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby">More at MDN →</a></aside>
-			<hr />
+			<hr>
 			
 			<!-- s -->
 			<a id="s"></a>
@@ -1639,7 +1639,7 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- samp -->
 			<a id="samp"></a>
@@ -1653,14 +1653,14 @@
 				</section>
 			</details>
 			<aside><a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp">More at MDN →</a></aside>
-			<hr />
+			<hr>
 
 			<!-- section -->
 			<a id="section"></a>
 			<h4><a href="#section"><code>&lt;section&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;section&gt;</code> element represents a standalone section — which doesn't have a more specific semantic element to represent it — contained within an HTML document.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section">More at MDN →</a>
 			</p>
 			<details open>
@@ -1669,14 +1669,14 @@
 					<p>A section element</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- select -->
 			<a id="select"></a>
 			<h4><a href="#select"><code>&lt;select&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;select&gt;</code> element represents a control that provides a menu of options.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select">More at MDN →</a>
 			</p>
 			<details open>
@@ -1694,14 +1694,14 @@
 					</select>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- small -->
 			<a id="small"></a>
 			<h4><a href="#small"><code>&lt;small&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;small&gt;</code> element represents side-comments and small print, like copyright and legal text, independent of its styled presentation. By default, it renders text within it one font-size smaller, such as from small to x-small.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small">More at MDN →</a>
 			</p>
 			<details open>
@@ -1710,14 +1710,14 @@
 					<p>A preceeding paragraph of text and then <small>some text within the small element</small> followed by some additional text.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- span -->
 			<a id="span"></a>
 			<h4><a href="#span"><code>&lt;span&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;span&gt;</code> element is a generic inline container for phrasing content, which does not inherently represent anything. It can be used to group elements for styling purposes (using the class or id attributes), or because they share attribute values, such as lang.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span">More at MDN →</a>
 			</p>
 			<details open>
@@ -1726,14 +1726,14 @@
 					<p>A preceeding paragraph of text and then <span>some text within the span element</span> followed by some additional text.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- strong -->
 			<a id="strong"></a>
 			<h4><a href="#strong"><code>&lt;strong&gt;</code></a></h4>
 			<p>
 				The HTML Strong Importance Element <code>&lt;strong&gt;</code> indicates that its contents have strong importance, seriousness, or urgency. Browsers typically render the contents in bold type.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong">More at MDN →</a>
 			</p>
 			<details open>
@@ -1742,14 +1742,14 @@
 					<p>Some paragraph of text that includes <strong>a strong importance element</strong>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- sub -->
 			<a id="sub"></a>
 			<h4><a href="#sub"><code>&lt;sub&gt;</code></a></h4>
 			<p>
 				The HTML Subscript element (<code>&lt;sub&gt;</code>) specifies inline text which should be displayed as subscript for solely typographical reasons.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub">More at MDN →</a>
 			</p>
 			<details open>
@@ -1758,14 +1758,14 @@
 					<p>A preceeding paragraph of text and then <sub>some text within the sub element</sub> followed by some additional text.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- sup -->
 			<a id="sup"></a>
 			<h4><a href="#sup"><code>&lt;sup&gt;</code></a></h4>
 			<p>
 				The HTML Superscript element (<code>&lt;sup&gt;</code>) specifies inline text which is to be displayed as superscript for solely typographical reasons.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup">More at MDN →</a>
 			</p>
 			<details open>
@@ -1774,7 +1774,7 @@
 					<p>A preceeding paragraph of text and then <sup>some text within the sup element</sup> followed by some additional text.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- table -->
 			<!-- tdbody -->
@@ -1806,7 +1806,7 @@
 			</p>
 			<p>
 				The HTML <code>&lt;table&gt;</code> element represents tabular data — that is, information presented in a two-dimensional table comprised of rows and columns of cells containing data.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table">More at MDN →</a>
 			</p>
 			<details open>
@@ -1853,14 +1853,14 @@
 					</table>					
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- time -->
 			<a id="time"></a>
 			<h4><a href="#time"><code>&lt;time&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;time&gt;</code> element represents a specific period in time.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time">More at MDN →</a>
 			</p>
 			<details open>
@@ -1869,14 +1869,14 @@
 					<p>At <time datetime="03:14:07">around 3:14AM UTC</time> on <time datetime="2038-01-19">Tuesday, 19 January in the year 2038</time> 32-bit Unix timestamps will no longer work.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- u -->
 			<a id="u"></a>
 			<h4><a href="#u"><code>&lt;u&gt;</code></a></h4>
 			<p>
 				The HTML Unarticulated Annotation Element (<code>&lt;u&gt;</code>) represents a span of inline text which should be rendered in a way that indicates that it has a non-textual annotation.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u">More at MDN →</a>
 			</p>
 			<details open>
@@ -1885,14 +1885,14 @@
 					<p>A paragraph of text which contains <u>an unarticulated annotation element</u>.</p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 			
 			<!-- ul -->
 			<a id="ul"></a>
 			<h4><a href="#ul"><code>&lt;ul&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;ul&gt;</code> element represents an unordered list of items, typically rendered as a bulleted list.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul">More at MDN →</a>
 			</p>
 			<details open>
@@ -1915,14 +1915,14 @@
 					</ul>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- var -->
 			<a id="var"></a>
 			<h4><a href="#var"><code>&lt;var&gt;</code></a></h4>
 			<p>
 				The HTML Variable element (<code>&lt;var&gt;</code>) represents the name of a variable in a mathematical expression or a programming context.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var">More at MDN →</a>
 			</p>
 			<details open>
@@ -1931,14 +1931,14 @@
 					<p>Euler's identity: <code><var>e</var><sup><var>i</var>π</sup> + 1 = 0</code></p>
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- video -->
 			<a id="video"></a>
 			<h4><a href="#video"><code>&lt;video&gt;</code></a></h4>
 			<p>
 				The HTML Video element <code>&lt;video&gt;</code> embeds a media player which supports video playback into the document. You can use <code>&lt;video&gt;</code> for audio content as well, but the <code>&lt;audio&gt;</code> element may provide a more appropriate user experience.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video">More at MDN →</a>
 			</p>
 			<details open>
@@ -1954,14 +1954,14 @@
 					</figure>		
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<!-- wbr -->
 			<a id="wbr"></a>
 			<h4><a href="#wbr"><code>&lt;wbr&gt;</code></a></h4>
 			<p>
 				The HTML <code>&lt;wbr&gt;</code> element represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location.
-				<br />
+				<br>
 				<a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr">More at MDN →</a>
 			</p>
 			<details open>
@@ -1972,7 +1972,7 @@
 					
 				</section>
 			</details>
-			<hr />
+			<hr>
 
 			<a id="omitted-elements"></a>
 			<h3>Omitted Elements</h3>
@@ -1998,7 +1998,7 @@
 			</ul>
 		</section>
 
-		<hr />
+		<hr>
 		<section>
 			
 			<a id="acknowledgements"></a>


### PR DESCRIPTION
- Fixes all errors, per https://validator.w3.org/
- Fixes most warnings.
  - Leaves `<section>` without header.  Arguably these could be stripped or replaced by a `<div>`.
  - Leaves multiple `<h1>`.  I think these are necessary to the purpose of the doc.